### PR TITLE
SPEC-249 Non-API public method in javax.faces.webapp.FacesServlet

### DIFF
--- a/impl/src/main/java/javax/faces/webapp/FacesServlet.java
+++ b/impl/src/main/java/javax/faces/webapp/FacesServlet.java
@@ -597,7 +597,7 @@ public final class FacesServlet implements Servlet {
         }
     }
     
-    public void initializeAllowedKnownHttpMethods(List<String> allowedKnownHttpMethodsStringList) {
+    private void initializeAllowedKnownHttpMethods(List<String> allowedKnownHttpMethodsStringList) {
         if (5 == allowedKnownHttpMethodsStringList.size()) {
             allowedKnownHttpMethods = EnumSet.of(
                     HttpMethod.valueOf(allowedKnownHttpMethodsStringList.get(0)),


### PR DESCRIPTION
fix an failed CTS test case: signature of FacesServlet.initializeAllowedKnownHttpMethods()