### PR TITLE
FISH-6596 Jakarta Form Data

### DIFF
--- a/action/pom.xml
+++ b/action/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -29,7 +29,7 @@
    <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0.payara-p1</version>
     </parent>
 
    <artifactId>jakarta.faces</artifactId>

--- a/impl/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js
+++ b/impl/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// Portions Copyright [2022] Payara Foundation and/or affiliates
 
 /**
  @project Faces JavaScript Library
@@ -2529,13 +2530,16 @@ if (!((faces && faces.specversion && faces.specversion >= 23000 ) &&
                 var namingContainerPrefix = viewStateElement.name.substring(0, viewStateElement.name.indexOf("jakarta.faces.ViewState"));
 
                 args[namingContainerPrefix + "jakarta.faces.source"] = element.id;
+                args[namingContainerPrefix + "javax.faces.source"] = element.id; // add javax duplicate arg
 
                 if (event && !!event.type) {
                     args[namingContainerPrefix + "jakarta.faces.partial.event"] = event.type;
+                    args[namingContainerPrefix + "javax.faces.partial.event"] = event.type; // add javax duplicate arg
                 }
 
                 if ("resetValues" in options) {
                     args[namingContainerPrefix + "jakarta.faces.partial.resetValues"] = options.resetValues;
+                    args[namingContainerPrefix + "javax.faces.partial.resetValues"] = options.resetValues;
                 }
 
                 // If we have 'execute' identifiers:
@@ -2563,10 +2567,12 @@ if (!((faces && faces.specversion && faces.specversion >= 23000 ) &&
                             options.execute = "@all";
                         }
                         args[namingContainerPrefix + "jakarta.faces.partial.execute"] = options.execute;
+                        args[namingContainerPrefix + "javax.faces.partial.execute"] = options.execute; // add javax duplicate arg
                     }
                 } else {
                     options.execute = element.name + " " + element.id;
                     args[namingContainerPrefix + "jakarta.faces.partial.execute"] = options.execute;
+                    args[namingContainerPrefix + "javax.faces.partial.execute"] = options.execute; // add javax duplicate arg
                 }
 
                 if (options.render) {
@@ -2583,6 +2589,7 @@ if (!((faces && faces.specversion && faces.specversion >= 23000 ) &&
                             options.render = "@all";
                         }
                         args[namingContainerPrefix + "jakarta.faces.partial.render"] = options.render;
+                        args[namingContainerPrefix + "javax.faces.partial.render"] = options.render; // add javax duplicate arg
                     }
                 }
                 var explicitlyDoNotDelay = ((typeof options.delay == 'undefined') || (typeof options.delay == 'string') &&
@@ -2649,11 +2656,19 @@ if (!((faces && faces.specversion && faces.specversion >= 23000 ) &&
                 for (var property in options) {
                     if (options.hasOwnProperty(property)) {
                         args[namingContainerPrefix + property] = options[property];
+                        if(property.startsWith("jakarta.")) {
+                             // add jakarta duplicate arg
+                            jakartaProperty = "javax."+property.substring("jakarta.".length);
+                            args[namingContainerPrefix + jakartaProperty] = options[property];
+                        }
                     }
                 }
 
                 args[namingContainerPrefix + "jakarta.faces.partial.ajax"] = "true";
+                args[namingContainerPrefix + "javax.faces.partial.ajax"] = "true"; // add javax duplicate arg
                 args["method"] = "POST";
+                 // add javax duplicate ViewState. It is added to parameters via viewState and queryString, so add javax version explicitly.
+                args[namingContainerPrefix + "javax.faces.ViewState"] = viewStateElement.value;
 
                 // Determine the posting url
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
    <groupId>org.glassfish</groupId>
    <artifactId>mojarra-parent</artifactId>
-   <version>4.0.0-SNAPSHOT</version>
+   <version>4.0.0.payara-p1</version>
    <packaging>pom</packaging>
 
    <name>Mojarra ${project.version} - Project</name>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>


### PR DESCRIPTION
This PR is the opposite case of https://github.com/payara/patched-src-mojarra/pull/17
The former PR was adding jakarta copies of javax parameters, while this PR uses newer Mojarra (already using jakarta names) and adds javax copies of jakarta parameters

Improvements for JakartaEE 9 applications, original idea is https://github.com/payara/Payara/issues/5842

The only change happens in jsf-uncompressed.js
All jakarta.faces.* post data is duplicated with javax.faces copies.

E.g. the reproducer application produced this output:
```
form: form
form:input: Message
jakarta.faces.behavior.event: action
jakarta.faces.partial.ajax: true
jakarta.faces.partial.event: click
jakarta.faces.partial.execute: form:jsfButton form:input
jakarta.faces.partial.render: form:output
jakarta.faces.source: form:jsfButton
jakarta.faces.ViewState: 3768650063610317665:-4574714117490412382
```

The new version produces this:

```
form: form
form:input: Message
javax.faces.ViewState: 1818319852855307414:-2863703350972090453
javax.faces.source: form:jsfButton
jakarta.faces.source: form:jsfButton
javax.faces.partial.event: click
jakarta.faces.partial.event: click
javax.faces.partial.execute: form:jsfButton form:input
jakarta.faces.partial.execute: form:jsfButton form:input
javax.faces.partial.render: form:output
jakarta.faces.partial.render: form:output
javax.faces.behavior.event: action
jakarta.faces.behavior.event: action
javax.faces.partial.ajax: true
jakarta.faces.partial.ajax: true
jakarta.faces.ViewState: 1818319852855307414:-2863703350972090453
```
