### PR TITLE
FISH-6596 fix issue with startsWith in faces TCK in version 2.3.18

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <artifactId>jakarta.faces</artifactId>

--- a/impl/src/main/resources/META-INF/resources/javax.faces/jsf-uncompressed.js
+++ b/impl/src/main/resources/META-INF/resources/javax.faces/jsf-uncompressed.js
@@ -2657,7 +2657,7 @@ if (!((jsf && jsf.specversion && jsf.specversion >= 23000 ) &&
                 for (var property in options) {
                     if (options.hasOwnProperty(property)) {
                         args[namingContainerPrefix + property] = options[property];
-                        if(property.startsWith("javax.")) {
+                        if(/^javax\./.test(property.toString())) {
                              // add jakarta duplicate arg
                             jakartaProperty = "jakarta."+property.substring("javax.".length);
                             args[namingContainerPrefix + jakartaProperty] = options[property];

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     
     <groupId>org.glassfish</groupId>
     <artifactId>mojarra-parent</artifactId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
     <packaging>pom</packaging>
     
     <name>Mojarra ${project.version} - Project</name>

--- a/test/cluster/javaee6web/flow/basic_faces_flow_call/pom.xml
+++ b/test/cluster/javaee6web/flow/basic_faces_flow_call/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.cluster.javaee6web.flow</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <artifactId>basic_faces_flow_call</artifactId>

--- a/test/cluster/javaee6web/flow/pom.xml
+++ b/test/cluster/javaee6web/flow/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test.cluster.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <groupId>com.sun.faces.test.cluster.javaee6web.flow</groupId>

--- a/test/cluster/javaee6web/noAggressiveSessionDirtying/pom.xml
+++ b/test/cluster/javaee6web/noAggressiveSessionDirtying/pom.xml
@@ -22,10 +22,10 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.cluster.javaee6web</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>noAggressiveSessionDirtying</artifactId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
     <packaging>war</packaging>
     <name>Mojarra ${project.version} - Test - Cluster - JavaEE 6 Web - No Aggressive Session Dirtying</name>
     <build>

--- a/test/cluster/javaee6web/pom.xml
+++ b/test/cluster/javaee6web/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.cluster</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.cluster.javaee6web</groupId>
     <artifactId>pom</artifactId>

--- a/test/cluster/javaee6web/viewScoped/pom.xml
+++ b/test/cluster/javaee6web/viewScoped/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.cluster.javaee6web</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <groupId>com.sun.faces.test.cluster.javaee6web</groupId>
   <artifactId>viewScoped</artifactId>
-  <version>2.3.18.payara-p1</version>
+  <version>2.3.18.payara-p2</version>
   <packaging>war</packaging>
   <name>Mojarra ${project.version} - Test - Cluster - JavaEE 6 Web - ViewScoped test</name>
   

--- a/test/cluster/pom.xml
+++ b/test/cluster/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.cluster</groupId>
     <artifactId>pom</artifactId>

--- a/test/cluster/servlet25/bytearrayguard/pom.xml
+++ b/test/cluster/servlet25/bytearrayguard/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.cluster.servlet25</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.cluster.servlet25</groupId>
     <artifactId>bytearrayguard</artifactId>

--- a/test/cluster/servlet25/flash/basic/pom.xml
+++ b/test/cluster/servlet25/flash/basic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.cluster.servlet25.flash</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.cluster.servlet25.flash</groupId>
     <artifactId>basic</artifactId>

--- a/test/cluster/servlet25/flash/pom.xml
+++ b/test/cluster/servlet25/flash/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.cluster.servlet25</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.cluster.servlet25.flash</groupId>
     <artifactId>pom</artifactId>

--- a/test/cluster/servlet25/flash/reaper/pom.xml
+++ b/test/cluster/servlet25/flash/reaper/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.cluster.servlet25.flash</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.cluster.servlet25.flash</groupId>
     <artifactId>reaper</artifactId>

--- a/test/cluster/servlet25/pom.xml
+++ b/test/cluster/servlet25/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.cluster</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.cluster.servlet25</groupId>
     <artifactId>pom</artifactId>

--- a/test/glassfish/admingui/pom.xml
+++ b/test/glassfish/admingui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.glassfish</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>admingui</artifactId>
     <packaging>war</packaging>

--- a/test/glassfish/bundle22/pom.xml
+++ b/test/glassfish/bundle22/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.glassfish</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.glassfish</groupId>
     <artifactId>bundle22</artifactId>

--- a/test/glassfish/facelets/core/pom.xml
+++ b/test/glassfish/facelets/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.glassfish.facelets</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.glassfish.facelets</groupId>
     <artifactId>core</artifactId>

--- a/test/glassfish/facelets/pom.xml
+++ b/test/glassfish/facelets/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.glassfish</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.glassfish.facelets</groupId>
     <artifactId>pom</artifactId>

--- a/test/glassfish/jpa/pom.xml
+++ b/test/glassfish/jpa/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.glassfish</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>jpa</artifactId>
     <packaging>war</packaging>

--- a/test/glassfish/pom.xml
+++ b/test/glassfish/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <groupId>com.sun.faces.test.glassfish</groupId>

--- a/test/glassfish/request_char_encoding/pom.xml
+++ b/test/glassfish/request_char_encoding/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.glassfish</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.glassfish</groupId>
     <artifactId>request_char_encoding</artifactId>

--- a/test/glassfish/request_char_encoding2/pom.xml
+++ b/test/glassfish/request_char_encoding2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.glassfish</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.glassfish</groupId>
     <artifactId>request_char_encoding2</artifactId>

--- a/test/glassfish/undeploy/pom.xml
+++ b/test/glassfish/undeploy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.glassfish</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.glassfish.undeploy</groupId>
     <artifactId>pom</artifactId>

--- a/test/glassfish/undeploy/undeploy1/pom.xml
+++ b/test/glassfish/undeploy/undeploy1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.glassfish.undeploy</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.glassfish.undeploy</groupId>
     <artifactId>undeploy1</artifactId>

--- a/test/glassfish/undeploy/undeploy2/pom.xml
+++ b/test/glassfish/undeploy/undeploy2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.glassfish.undeploy</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.glassfish.undeploy</groupId>
     <artifactId>undeploy2</artifactId>

--- a/test/htmlunitaware/htmlunit224/pom.xml
+++ b/test/htmlunitaware/htmlunit224/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.htmlunitaware</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <artifactId>htmlunit224</artifactId>

--- a/test/htmlunitaware/pom.xml
+++ b/test/htmlunitaware/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
 
     <groupId>com.sun.faces.test.htmlunitaware</groupId>

--- a/test/javaee6/correctScanningEar/pom.xml
+++ b/test/javaee6/correctScanningEar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>correctScanningEar</artifactId>
     <packaging>ear</packaging>

--- a/test/javaee6/correctScanningJar/pom.xml
+++ b/test/javaee6/correctScanningJar/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>correctScanningJar</artifactId>
     <packaging>jar</packaging>

--- a/test/javaee6/correctScanningTest/pom.xml
+++ b/test/javaee6/correctScanningTest/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>correctScanningTest</artifactId>
     <packaging>jar</packaging>

--- a/test/javaee6/correctScanningWar1/pom.xml
+++ b/test/javaee6/correctScanningWar1/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>correctScanningWar1</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6/correctScanningWar2/pom.xml
+++ b/test/javaee6/correctScanningWar2/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>correctScanningWar2</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6/pom.xml
+++ b/test/javaee6/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
 
     <groupId>com.sun.faces.test.javaee6</groupId>

--- a/test/javaee6/resource/cacheLastMod/ear/pom.xml
+++ b/test/javaee6/resource/cacheLastMod/ear/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6.resource.cacheLastMod</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <name>Mojarra ${project.version} - Test - JavaEE 6 - resource - cacheLastMod - ear</name>
     <groupId>com.sun.faces.test.javaee6.resource.cacheLastMod</groupId>

--- a/test/javaee6/resource/cacheLastMod/jar/pom.xml
+++ b/test/javaee6/resource/cacheLastMod/jar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6.resource.cacheLastMod</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <name>Mojarra ${project.version} - Test - JavaEE 6 - resource - cacheLastMod - jar</name>
     <groupId>com.sun.faces.test.javaee6.resource.cacheLastMod</groupId>

--- a/test/javaee6/resource/cacheLastMod/pom.xml
+++ b/test/javaee6/resource/cacheLastMod/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6.resource</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.javaee6.resource.cacheLastMod</groupId>
     <artifactId>pom</artifactId>

--- a/test/javaee6/resource/cacheLastMod/war-test/pom.xml
+++ b/test/javaee6/resource/cacheLastMod/war-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6.resource.cacheLastMod</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <name>Mojarra ${project.version} - Test - JavaEE 6 - resource - cacheLastMod - war-test</name>
     <groupId>com.sun.faces.test.javaee6.resource.cacheLastMod</groupId>

--- a/test/javaee6/resource/cacheLastMod/war/pom.xml
+++ b/test/javaee6/resource/cacheLastMod/war/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6.resource.cacheLastMod</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <name>Mojarra ${project.version} - Test - JavaEE 6 - resource - cacheLastMod - war</name>
     <groupId>com.sun.faces.test.javaee6.resource.cacheLastMod</groupId>

--- a/test/javaee6/resource/pom.xml
+++ b/test/javaee6/resource/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.javaee6.resource</groupId>
     <artifactId>pom</artifactId>

--- a/test/javaee6/viewParamBeanValidatorNotNull/pom.xml
+++ b/test/javaee6/viewParamBeanValidatorNotNull/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.javaee6</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <artifactId>viewParamBeanValidatorNotNull</artifactId>

--- a/test/javaee6/viewParamNullValueAjax/pom.xml
+++ b/test/javaee6/viewParamNullValueAjax/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.javaee6</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <artifactId>viewParamNullValueAjax</artifactId>

--- a/test/javaee6web/ajax/pom.xml
+++ b/test/javaee6web/ajax/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>ajaxc</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/basicFlow/pom.xml
+++ b/test/javaee6web/basicFlow/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>basicFlow</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/disallowDoctypeDecl/pom.xml
+++ b/test/javaee6web/disallowDoctypeDecl/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.javaee6web</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <groupId>com.sun.faces.test.javaee6web</groupId>
   <artifactId>disallowDoctypeDecl</artifactId>
-  <version>2.3.18.payara-p1</version>
+  <version>2.3.18.payara-p2</version>
   <packaging>war</packaging>
   <name>Mojarra ${project.version} - Test - JavaEE 6 Web - Disallow Doctype Declaration</name>
   

--- a/test/javaee6web/el/pom.xml
+++ b/test/javaee6web/el/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>el</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/emptyFlowDefinition/pom.xml
+++ b/test/javaee6web/emptyFlowDefinition/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>emptyFlowDefinition</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/faceletDefaultSuffix/pom.xml
+++ b/test/javaee6web/faceletDefaultSuffix/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.javaee6web</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <groupId>com.sun.faces.test.javaee6web</groupId>
   <artifactId>faceletDefaultSuffix</artifactId>
-  <version>2.3.18.payara-p1</version>
+  <version>2.3.18.payara-p2</version>
   <packaging>war</packaging>
   <name>Mojarra ${project.version} - Test - JavaEE 6 Web - Facelet Default Suffix</name>
   

--- a/test/javaee6web/facelets/pom.xml
+++ b/test/javaee6web/facelets/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>facelets</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowAndTemplateInJar/pom.xml
+++ b/test/javaee6web/flowAndTemplateInJar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowAndTemplateInJar</artifactId>
     <packaging>jar</packaging>

--- a/test/javaee6web/flowAndTemplateUsingJar/pom.xml
+++ b/test/javaee6web/flowAndTemplateUsingJar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowAndTemplateUsingJar</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowCall/pom.xml
+++ b/test/javaee6web/flowCall/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowCall</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowCallWithParameters/pom.xml
+++ b/test/javaee6web/flowCallWithParameters/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowCallWithParameters</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowDefiningDocumentId/pom.xml
+++ b/test/javaee6web/flowDefiningDocumentId/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowDefiningDocumentId</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowDefiningDocumentIdJar1/pom.xml
+++ b/test/javaee6web/flowDefiningDocumentIdJar1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowDefiningDocumentIdJar1</artifactId>
     <packaging>jar</packaging>

--- a/test/javaee6web/flowDefiningDocumentIdJar2/pom.xml
+++ b/test/javaee6web/flowDefiningDocumentIdJar2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowDefiningDocumentIdJar2</artifactId>
     <packaging>jar</packaging>

--- a/test/javaee6web/flowDefinitionInWebinf/pom.xml
+++ b/test/javaee6web/flowDefinitionInWebinf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowDefinitionInWebinf</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowFactory/pom.xml
+++ b/test/javaee6web/flowFactory/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowFactory</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowInXmlAndJava/pom.xml
+++ b/test/javaee6web/flowInXmlAndJava/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowInXmlAndJava</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowMethodCall/pom.xml
+++ b/test/javaee6web/flowMethodCall/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowMethodCall</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowReturnFromDepth/pom.xml
+++ b/test/javaee6web/flowReturnFromDepth/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowReturnFromDepth</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowSwitchCall/pom.xml
+++ b/test/javaee6web/flowSwitchCall/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowSwitchCall</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowTraversalCombinations/pom.xml
+++ b/test/javaee6web/flowTraversalCombinations/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowTraversalCombinations</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/flowViewNodeDifferent/pom.xml
+++ b/test/javaee6web/flowViewNodeDifferent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flowViewNodeDifferent</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/getNavigationCase-not-idempotent-issue-4279/pom.xml
+++ b/test/javaee6web/getNavigationCase-not-idempotent-issue-4279/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.javaee6web</groupId>
     <artifactId>getNavigationCase-not-idempotent-issue-4279</artifactId>

--- a/test/javaee6web/implicitFlow/pom.xml
+++ b/test/javaee6web/implicitFlow/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>implicitFlow</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/injectArtifacts/pom.xml
+++ b/test/javaee6web/injectArtifacts/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>injectArtifacts</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/injection/pom.xml
+++ b/test/javaee6web/injection/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>injection</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/multiPageFlowInJar/pom.xml
+++ b/test/javaee6web/multiPageFlowInJar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>multiPageFlowInJar</artifactId>
     <packaging>jar</packaging>

--- a/test/javaee6web/multiPageFlowUsingJar/pom.xml
+++ b/test/javaee6web/multiPageFlowUsingJar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>multiPageFlowUsingJar</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/nestedFlow/pom.xml
+++ b/test/javaee6web/nestedFlow/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>nestedFlow</artifactId>
     <packaging>war</packaging>

--- a/test/javaee6web/pom.xml
+++ b/test/javaee6web/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <groupId>com.sun.faces.test.javaee6web</groupId>

--- a/test/javaee6web/viewScope/pom.xml
+++ b/test/javaee6web/viewScope/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee6web</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>viewScope</artifactId>
     <packaging>war</packaging>

--- a/test/javaee7/cdiBeanValidator/pom.xml
+++ b/test/javaee7/cdiBeanValidator/pom.xml
@@ -24,10 +24,10 @@
     <parent>
         <groupId>com.sun.faces.test.javaee7</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>cdiBeanValidator</artifactId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
     <packaging>war</packaging>
     <name>Mojarra ${project.version} - Test - JavaEE 7 - CDI BeanValidator</name>  
     <build>

--- a/test/javaee7/cdiInitDestroyEvent/pom.xml
+++ b/test/javaee7/cdiInitDestroyEvent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee7</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>cdiInitDestroyEvent</artifactId>
     <packaging>war</packaging>

--- a/test/javaee7/cdiMethodValidation/pom.xml
+++ b/test/javaee7/cdiMethodValidation/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee7</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>cdiMethodValidation</artifactId>
     <packaging>war</packaging>

--- a/test/javaee7/cdiMultiTenantJspSetsTccl/pom.xml
+++ b/test/javaee7/cdiMultiTenantJspSetsTccl/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee7</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>cdiMultiTenantJspSetsTccl</artifactId>
     <packaging>war</packaging>

--- a/test/javaee7/cdiMultiTenantSetsTccl/pom.xml
+++ b/test/javaee7/cdiMultiTenantSetsTccl/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee7</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>cdiMultiTenantSetsTccl</artifactId>
     <packaging>war</packaging>

--- a/test/javaee7/cdiNoBeansXml/pom.xml
+++ b/test/javaee7/cdiNoBeansXml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee7</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>  
     <artifactId>cdiNoBeansXml</artifactId>
     <packaging>war</packaging>

--- a/test/javaee7/el/pom.xml
+++ b/test/javaee7/el/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee7</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>el</artifactId>
     <packaging>war</packaging>

--- a/test/javaee7/facelets/pom.xml
+++ b/test/javaee7/facelets/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.javaee7</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>facelets</artifactId>
     <packaging>war</packaging> 

--- a/test/javaee7/multiFieldValidation/pom.xml
+++ b/test/javaee7/multiFieldValidation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee7</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>multiFieldValidation</artifactId>
     <packaging>war</packaging>

--- a/test/javaee7/pom.xml
+++ b/test/javaee7/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.javaee7</groupId>
     <artifactId>pom</artifactId>

--- a/test/javaee7/protectedView/pom.xml
+++ b/test/javaee7/protectedView/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.javaee7</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <artifactId>protectedView</artifactId>

--- a/test/javaee7/viewActionCdiViewScoped/pom.xml
+++ b/test/javaee7/viewActionCdiViewScoped/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.javaee7</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <groupId>com.sun.faces.test.javaee7</groupId>
   <artifactId>viewActionCdiViewScoped</artifactId>
-  <version>2.3.18.payara-p1</version>
+  <version>2.3.18.payara-p2</version>
   <packaging>war</packaging>
   <name>Mojarra ${project.version} - Test - JavaEE 7 - ViewAction CDI ViewScoped</name>
   

--- a/test/javaee8/ajax/pom.xml
+++ b/test/javaee8/ajax/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.javaee8</groupId>
     <artifactId>ajax</artifactId>

--- a/test/javaee8/cdi/pom.xml
+++ b/test/javaee8/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.javaee8</groupId>
     <artifactId>cdi</artifactId>

--- a/test/javaee8/commandScript/pom.xml
+++ b/test/javaee8/commandScript/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>commandScript</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/converter/pom.xml
+++ b/test/javaee8/converter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>converter</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/disableFaceletToXhtmlMapping/pom.xml
+++ b/test/javaee8/disableFaceletToXhtmlMapping/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.javaee8</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <groupId>com.sun.faces.test.javaee8</groupId>
   <artifactId>disablefacelettoxhtmlmapping</artifactId>
-  <version>2.3.18.payara-p1</version>
+  <version>2.3.18.payara-p2</version>
   <packaging>war</packaging>
 
   <name>Mojarra ${project.version} - Test - JavaEE 8 - Disable Facelet To Xhtml Mapping</name>

--- a/test/javaee8/disableFaceletsViewHandler/pom.xml
+++ b/test/javaee8/disableFaceletsViewHandler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>disableFaceletsViewHandler</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/disableFaceletsViewHandlerDeprecated/pom.xml
+++ b/test/javaee8/disableFaceletsViewHandlerDeprecated/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>disableViewHandlerDeprecated</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/el/pom.xml
+++ b/test/javaee8/el/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.javaee8</groupId>
     <artifactId>el</artifactId>

--- a/test/javaee8/facelets/pom.xml
+++ b/test/javaee8/facelets/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>facelets</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/flash/pom.xml
+++ b/test/javaee8/flash/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flash</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/importConstants/pom.xml
+++ b/test/javaee8/importConstants/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>importConstants</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/localizedResources/pom.xml
+++ b/test/javaee8/localizedResources/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <artifactId>LocalizedResources</artifactId>

--- a/test/javaee8/namespacedView/pom.xml
+++ b/test/javaee8/namespacedView/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.javaee8</groupId>
     <artifactId>namespacedView</artifactId>

--- a/test/javaee8/passthrough/pom.xml
+++ b/test/javaee8/passthrough/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>passthrough</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/pom.xml
+++ b/test/javaee8/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <groupId>com.sun.faces.test.javaee8</groupId>

--- a/test/javaee8/searchExpression/pom.xml
+++ b/test/javaee8/searchExpression/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>searchExpression</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/uiinput-required-true/pom.xml
+++ b/test/javaee8/uiinput-required-true/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>uiinput-required-true</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/uiinput/pom.xml
+++ b/test/javaee8/uiinput/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>uiinput</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/validateWholeBean/pom.xml
+++ b/test/javaee8/validateWholeBean/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <artifactId>validateWholeBean</artifactId>

--- a/test/javaee8/websocket/pom.xml
+++ b/test/javaee8/websocket/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>websocket</artifactId>
     <packaging>war</packaging>

--- a/test/javaee8/xhtmlMappingToFaceletByDefault/pom.xml
+++ b/test/javaee8/xhtmlMappingToFaceletByDefault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.javaee8</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>xhtmlmappingtofaceletbydefault</artifactId>
     <packaging>war</packaging>

--- a/test/osgi/pom.xml
+++ b/test/osgi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <groupId>com.sun.faces.test.osgi</groupId>

--- a/test/osgi/simple/pom.xml
+++ b/test/osgi/simple/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.osgi</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>simple</artifactId>
     <packaging>war</packaging>

--- a/test/osgi/wabJar/pom.xml
+++ b/test/osgi/wabJar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.osgi</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>wabJar</artifactId>
     <packaging>jar</packaging>

--- a/test/osgi/wabWar/pom.xml
+++ b/test/osgi/wabWar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.osgi</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>wabWar</artifactId>
     <packaging>war</packaging>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>com.sun.faces.test</groupId>
     <artifactId>pom</artifactId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
     <packaging>pom</packaging>
 
     <name>Mojarra ${project.version} - Test</name>
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>com.sun.faces</groupId>
             <artifactId>util</artifactId>
-            <version>2.3.18.payara-p1</version>
+            <version>2.3.18.payara-p2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/test/protocolaware/annotationScanning/pom.xml
+++ b/test/protocolaware/annotationScanning/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.protocolaware</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>annotationScanning</artifactId>
     <packaging>war</packaging>

--- a/test/protocolaware/flash/basic/pom.xml
+++ b/test/protocolaware/flash/basic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.protocolaware.flash</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.protocolaware.flash</groupId>
     <artifactId>basic</artifactId>

--- a/test/protocolaware/flash/pom.xml
+++ b/test/protocolaware/flash/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.protocolaware</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.protocolaware.flash</groupId>
     <artifactId>pom</artifactId>

--- a/test/protocolaware/pom.xml
+++ b/test/protocolaware/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
 
     <groupId>com.sun.faces.test.protocolaware</groupId>

--- a/test/servlet30-isolated/cactus/pom.xml
+++ b/test/servlet30-isolated/cactus/pom.xml
@@ -22,7 +22,7 @@
         <parent>
         <groupId>com.sun.faces.test.servlet30_isolated</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>cactus</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30-isolated/converterPropertyEditor/pom.xml
+++ b/test/servlet30-isolated/converterPropertyEditor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30_isolated</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>converterPropertyEditor</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30-isolated/coreTags/pom.xml
+++ b/test/servlet30-isolated/coreTags/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30_isolated</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>coreTags</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30-isolated/pom.xml
+++ b/test/servlet30-isolated/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <groupId>com.sun.faces.test.servlet30_isolated</groupId>

--- a/test/servlet30/absoluteOrdering/pom.xml
+++ b/test/servlet30/absoluteOrdering/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.servlet30</groupId>
     <artifactId>absoluteOrdering</artifactId>

--- a/test/servlet30/ajax/pom.xml
+++ b/test/servlet30/ajax/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <artifactId>ajax</artifactId>

--- a/test/servlet30/ajaxNamespace/pom.xml
+++ b/test/servlet30/ajaxNamespace/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>ajaxNamespace</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/annotationRestrictions/pom.xml
+++ b/test/servlet30/annotationRestrictions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>annotationRestrictions</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/appUsingJarWithExactlyTwoContracts/pom.xml
+++ b/test/servlet30/appUsingJarWithExactlyTwoContracts/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>appUsingJarWithExactlyTwoContracts</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/application/pom.xml
+++ b/test/servlet30/application/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>application</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/bogusRenderKitId/pom.xml
+++ b/test/servlet30/bogusRenderKitId/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>bogusRenderKitId</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/characterCombat/pom.xml
+++ b/test/servlet30/characterCombat/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>characterCombat</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/client-encrypt-by-default-disabled/pom.xml
+++ b/test/servlet30/client-encrypt-by-default-disabled/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>client-encrypt-by-default-disabled</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/client-encrypt-by-default/pom.xml
+++ b/test/servlet30/client-encrypt-by-default/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>client-encrypt-by-default</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/clientsideStateSaving/pom.xml
+++ b/test/servlet30/clientsideStateSaving/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>clientsideStateSaving</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/component/pom.xml
+++ b/test/servlet30/component/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>component</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/composite/pom.xml
+++ b/test/servlet30/composite/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.servlet30</groupId>
     <artifactId>composite</artifactId>

--- a/test/servlet30/composite2/pom.xml
+++ b/test/servlet30/composite2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>composite2</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/composite2Jar/pom.xml
+++ b/test/servlet30/composite2Jar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>composite2Jar</artifactId>
     <packaging>jar</packaging>

--- a/test/servlet30/compositeComponentForAttribute/pom.xml
+++ b/test/servlet30/compositeComponentForAttribute/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>compositeComponentForAttribute</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/configBasic/pom.xml
+++ b/test/servlet30/configBasic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>configBasic</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/configEmbed/pom.xml
+++ b/test/servlet30/configEmbed/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>configEmbed</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/configExtra/pom.xml
+++ b/test/servlet30/configExtra/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>configExtra</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/configFile/pom.xml
+++ b/test/servlet30/configFile/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>configFile</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/configInJarOnly/pom.xml
+++ b/test/servlet30/configInJarOnly/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>configInJarOnly</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/configInJarOnlyJar/pom.xml
+++ b/test/servlet30/configInJarOnlyJar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>configInJarOnlyJar</artifactId>
     <packaging>jar</packaging>

--- a/test/servlet30/configLowercase/pom.xml
+++ b/test/servlet30/configLowercase/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>configLowercase</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/content-type/pom.xml
+++ b/test/servlet30/content-type/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.servlet30</groupId>
     <artifactId>content-type</artifactId>

--- a/test/servlet30/contractBasic/pom.xml
+++ b/test/servlet30/contractBasic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractBasic</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/contractBasicInJar/pom.xml
+++ b/test/servlet30/contractBasicInJar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractBasicInJar</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/contractBasicJar/pom.xml
+++ b/test/servlet30/contractBasicJar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractBasicJar</artifactId>
     <packaging>jar</packaging>

--- a/test/servlet30/contractExtended/pom.xml
+++ b/test/servlet30/contractExtended/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractExtended</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/contractExtendedBase/pom.xml
+++ b/test/servlet30/contractExtendedBase/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractExtendedBase</artifactId>
     <packaging>jar</packaging>

--- a/test/servlet30/contractExtendedBlue/pom.xml
+++ b/test/servlet30/contractExtendedBlue/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractExtendedBlue</artifactId>
     <packaging>jar</packaging>

--- a/test/servlet30/contractExtendedRed/pom.xml
+++ b/test/servlet30/contractExtendedRed/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractExtendedRed</artifactId>
     <packaging>jar</packaging>

--- a/test/servlet30/contractSample/pom.xml
+++ b/test/servlet30/contractSample/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractSample</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/contractSimple/pom.xml
+++ b/test/servlet30/contractSimple/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractSimple</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/contractUsingHostHeader/pom.xml
+++ b/test/servlet30/contractUsingHostHeader/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractUsingHostHeader</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/contractUsingViewRoot/pom.xml
+++ b/test/servlet30/contractUsingViewRoot/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>contractUsingViewRoot</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/converter/pom.xml
+++ b/test/servlet30/converter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>converter</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/converterNPE/pom.xml
+++ b/test/servlet30/converterNPE/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>converterNPE</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/customFaceletsResolver/pom.xml
+++ b/test/servlet30/customFaceletsResolver/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>customFaceletsResolver</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/customLifecycle/pom.xml
+++ b/test/servlet30/customLifecycle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>customLifecycle</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/customPropertyResolverJsp/pom.xml
+++ b/test/servlet30/customPropertyResolverJsp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>customPropertyResolverJsp</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/customResolvers/pom.xml
+++ b/test/servlet30/customResolvers/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>customResolvers</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/customResourcesDirectory/pom.xml
+++ b/test/servlet30/customResourcesDirectory/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>customResourcesDirectory</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/customStateManager/pom.xml
+++ b/test/servlet30/customStateManager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>customStateManager</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/customVariableResolver/pom.xml
+++ b/test/servlet30/customVariableResolver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>customVariableResolver</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/customVariableResolverProgrammatically/pom.xml
+++ b/test/servlet30/customVariableResolverProgrammatically/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>customVariableResolverProgrammatically</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/customViewHandler/pom.xml
+++ b/test/servlet30/customViewHandler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>customViewHandler</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/customViewRootViewScope/pom.xml
+++ b/test/servlet30/customViewRootViewScope/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>customViewRootViewScope</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/disableBeanValidator/pom.xml
+++ b/test/servlet30/disableBeanValidator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>disableBeanValidator</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/disableIdUniqueness/pom.xml
+++ b/test/servlet30/disableIdUniqueness/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>disableIdUniqueness</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/disableUnicodeEscaping/pom.xml
+++ b/test/servlet30/disableUnicodeEscaping/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>disableUnicodeEscaping</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/doctypeHtml5/pom.xml
+++ b/test/servlet30/doctypeHtml5/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>doctypeHtml5</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/doctypeXhtml/pom.xml
+++ b/test/servlet30/doctypeXhtml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>doctypeXhtml</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/documentOrdering/pom.xml
+++ b/test/servlet30/documentOrdering/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>documentOrdering</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/dynamic/pom.xml
+++ b/test/servlet30/dynamic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.servlet30</groupId>
     <artifactId>dynamic</artifactId>

--- a/test/servlet30/dynamicChildAtCorrectIndex/pom.xml
+++ b/test/servlet30/dynamicChildAtCorrectIndex/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>dynamicChildAtCorrectIndex</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/dynamicTransientParent/pom.xml
+++ b/test/servlet30/dynamicTransientParent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>dynamicTransientParent</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/el/pom.xml
+++ b/test/servlet30/el/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>el</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/elDecoratedFacesContext/pom.xml
+++ b/test/servlet30/elDecoratedFacesContext/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>elDecoratedFacesContext</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/exactMapping/pom.xml
+++ b/test/servlet30/exactMapping/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet30</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>exactMapping</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/externalContext/pom.xml
+++ b/test/servlet30/externalContext/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>basic</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/faceletResourceResolver/pom.xml
+++ b/test/servlet30/faceletResourceResolver/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.servlet30</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <groupId>com.sun.faces.test.servlet30</groupId>
   <artifactId>faceletResourceResolver</artifactId>
-  <version>2.3.18.payara-p1</version>
+  <version>2.3.18.payara-p2</version>
   <packaging>war</packaging>
   <name>Mojarra ${project.version} - Test - Servlet 3.0 - Facelets ResourceResolver</name>
   <build>

--- a/test/servlet30/faceletResourceResolver2/pom.xml
+++ b/test/servlet30/faceletResourceResolver2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet30</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>faceletResourceResolver2</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/facelets/pom.xml
+++ b/test/servlet30/facelets/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>facelets</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/faceletsEmptyAsNull/pom.xml
+++ b/test/servlet30/faceletsEmptyAsNull/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>faceletsEmptyAsNull</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/faceletsFindChild/pom.xml
+++ b/test/servlet30/faceletsFindChild/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet30</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>faceletsFindChild</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/faceletsViewAction/pom.xml
+++ b/test/servlet30/faceletsViewAction/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet30</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>  
     <groupId>com.sun.faces.test.agnostic.facelets.viewAction</groupId>
     <artifactId>test-agnostic-facelets-viewAction-newsReader</artifactId>

--- a/test/servlet30/facesComponentTag/pom.xml
+++ b/test/servlet30/facesComponentTag/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>facesComponentTag</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/facesContext/pom.xml
+++ b/test/servlet30/facesContext/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>facesContext</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/facesContextInit/pom.xml
+++ b/test/servlet30/facesContextInit/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>facesContextInit</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/factory/pom.xml
+++ b/test/servlet30/factory/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.servlet30</groupId>
     <artifactId>factory</artifactId>

--- a/test/servlet30/findResourcesInJar/pom.xml
+++ b/test/servlet30/findResourcesInJar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>findResourcesInJar</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/flash/pom.xml
+++ b/test/servlet30/flash/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet30</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flash</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/flashBasic/pom.xml
+++ b/test/servlet30/flashBasic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet30</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flashBasic</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/flashChunkRedirect/pom.xml
+++ b/test/servlet30/flashChunkRedirect/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flashChunkRedirect</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/flashCustom/pom.xml
+++ b/test/servlet30/flashCustom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>  
     <artifactId>flashCustom</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/flashForceWriteCookie/pom.xml
+++ b/test/servlet30/flashForceWriteCookie/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.servlet30</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <groupId>com.sun.faces.test.servlet30</groupId>
   <artifactId>flashForceWriteCookie</artifactId>
-  <version>2.3.18.payara-p1</version>
+  <version>2.3.18.payara-p2</version>
   <packaging>war</packaging>
   <name>Mojarra ${project.version} - Test - Servlet 3.0 - Flash With ForceCookieWrite context-param</name>
   

--- a/test/servlet30/flashNoSession/pom.xml
+++ b/test/servlet30/flashNoSession/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>flashNoSession</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/implicitContract/pom.xml
+++ b/test/servlet30/implicitContract/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>implicitContract</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/initRequestParameterMap/pom.xml
+++ b/test/servlet30/initRequestParameterMap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>initRequestParameterMap</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/invalidMapping/pom.xml
+++ b/test/servlet30/invalidMapping/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>invalidMapping</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/jarOrdering/pom.xml
+++ b/test/servlet30/jarOrdering/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>jarOrdering</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/jarWithExactlyTwoContracts/pom.xml
+++ b/test/servlet30/jarWithExactlyTwoContracts/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>jarWithExactlyTwoContracts</artifactId>
     <packaging>jar</packaging>

--- a/test/servlet30/jspFlash/pom.xml
+++ b/test/servlet30/jspFlash/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>jspFlash</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/lateBindings/pom.xml
+++ b/test/servlet30/lateBindings/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>lateBindings</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/lifecycleBasic/pom.xml
+++ b/test/servlet30/lifecycleBasic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>lifecycleBasic</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/lifecycleClientWindow/pom.xml
+++ b/test/servlet30/lifecycleClientWindow/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>lifecycleClientWindow</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/lifecycleCsrf/pom.xml
+++ b/test/servlet30/lifecycleCsrf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>lifecycleCsrf</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/lifecycleDebugOutputStream/pom.xml
+++ b/test/servlet30/lifecycleDebugOutputStream/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>lifecycleDebugObjectOutputStream</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/lifecycleFacesServletAccess/pom.xml
+++ b/test/servlet30/lifecycleFacesServletAccess/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>lifecycleFacesServletAccess</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/lifecycleOptionsRequest/pom.xml
+++ b/test/servlet30/lifecycleOptionsRequest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>lifecycleOptionsRequest</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/lifecycleServerStateNegative/pom.xml
+++ b/test/servlet30/lifecycleServerStateNegative/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>lifecycleServerStateNegative</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/lifecycleServerStatePositive/pom.xml
+++ b/test/servlet30/lifecycleServerStatePositive/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>lifecycleServerStatePositive</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/listener/pom.xml
+++ b/test/servlet30/listener/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>listener</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/localeConfig/pom.xml
+++ b/test/servlet30/localeConfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>localeConfig</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/multiTenantSetsTccl/pom.xml
+++ b/test/servlet30/multiTenantSetsTccl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet30</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>app-sets-tccl</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/multiTenantUsesFactoryFinder/pom.xml
+++ b/test/servlet30/multiTenantUsesFactoryFinder/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet30</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>multiTenantUsesFactoryFinder</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/navigation/pom.xml
+++ b/test/servlet30/navigation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.servlet30</groupId>
     <artifactId>navigation</artifactId>

--- a/test/servlet30/navigation2/pom.xml
+++ b/test/servlet30/navigation2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>navigation2</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/navigation3/pom.xml
+++ b/test/servlet30/navigation3/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>navigation3</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/nestedDataTables/pom.xml
+++ b/test/servlet30/nestedDataTables/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>nestedDataTables</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/nestedLoadBundles/pom.xml
+++ b/test/servlet30/nestedLoadBundles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>nestedLoadBundles</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/neverUnwrapExceptions/pom.xml
+++ b/test/servlet30/neverUnwrapExceptions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>neverUnwrapExceptions</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/noWebXml/pom.xml
+++ b/test/servlet30/noWebXml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>noWebXml</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/passthrough/pom.xml
+++ b/test/servlet30/passthrough/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>passthrough</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/pom.xml
+++ b/test/servlet30/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <groupId>com.sun.faces.test.servlet30</groupId>

--- a/test/servlet30/processAsHtml5/pom.xml
+++ b/test/servlet30/processAsHtml5/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>processAsHtml5</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/processAsJspx/pom.xml
+++ b/test/servlet30/processAsJspx/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>processAsJspx</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/processAsXhtml5/pom.xml
+++ b/test/servlet30/processAsXhtml5/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>processAsXhtml5</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/renderKit/pom.xml
+++ b/test/servlet30/renderKit/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>renderKit</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/requestCharEncodingNoSession/pom.xml
+++ b/test/servlet30/requestCharEncodingNoSession/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>requestCharEncodingNoSession</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/resource/pom.xml
+++ b/test/servlet30/resource/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>resource</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/resourceExposure/pom.xml
+++ b/test/servlet30/resourceExposure/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet30</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>  
     <artifactId>resourceExposure</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/runtimeConfig/pom.xml
+++ b/test/servlet30/runtimeConfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>runtimeConfig</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/serializeServerState/pom.xml
+++ b/test/servlet30/serializeServerState/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>serializeServerState</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/sessionScope/pom.xml
+++ b/test/servlet30/sessionScope/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>sessionScope</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/stateViewExpiredExceptionMissing/pom.xml
+++ b/test/servlet30/stateViewExpiredExceptionMissing/pom.xml
@@ -22,10 +22,10 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>stateViewExpiredExceptionMissing</artifactId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
     <packaging>war</packaging>
     <name>Mojarra ${project.version} - Test - Servlet 3.0 - State ViewExpiredException Missing</name>
     <build>

--- a/test/servlet30/stringConverter/pom.xml
+++ b/test/servlet30/stringConverter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>stringConverter</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/suppressXmlDeclaration/pom.xml
+++ b/test/servlet30/suppressXmlDeclaration/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>suppressXmlDeclaration</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/systest/pom.xml
+++ b/test/servlet30/systest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <artifactId>systest</artifactId>

--- a/test/servlet30/viewExpiredException/pom.xml
+++ b/test/servlet30/viewExpiredException/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>viewExpiredException</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/viewRootPhaseListener/pom.xml
+++ b/test/servlet30/viewRootPhaseListener/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.servlet30</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <groupId>com.sun.faces.test.servlet30</groupId>
   <artifactId>viewRootPhaseListener</artifactId>
-  <version>2.3.18.payara-p1</version>
+  <version>2.3.18.payara-p2</version>
   <packaging>war</packaging>
   <name>Mojarra ${project.version} - Test - Servlet 3.0 - ViewRoot PhaseListener</name>
  

--- a/test/servlet30/viewRootPhaseListenerNoContextParam/pom.xml
+++ b/test/servlet30/viewRootPhaseListenerNoContextParam/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>com.sun.faces.test.servlet30</groupId>
-    <version>2.3.18.payara-p1</version>
+    <version>2.3.18.payara-p2</version>
   </parent>
   
   <groupId>com.sun.faces.test.servlet30</groupId>
   <artifactId>viewRootPhaseListenerNoContextParam</artifactId>
-  <version>2.3.18.payara-p1</version>
+  <version>2.3.18.payara-p2</version>
   <packaging>war</packaging>
   <name>Mojarra ${project.version} - Test - Servlet 3.0 - ViewRoot PhaseListener No context-param</name>
  

--- a/test/servlet30/viewScopeFailover/pom.xml
+++ b/test/servlet30/viewScopeFailover/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.servlet30</groupId>
     <artifactId>viewScopeFailover</artifactId>

--- a/test/servlet30/wcagDataTable/pom.xml
+++ b/test/servlet30/wcagDataTable/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>wcagDataTable</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/writeAttributeScriptDisabled/pom.xml
+++ b/test/servlet30/writeAttributeScriptDisabled/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>writeAttributeScriptDisabled</artifactId>
     <packaging>war</packaging>

--- a/test/servlet30/writeAttributeScriptEnabled/pom.xml
+++ b/test/servlet30/writeAttributeScriptEnabled/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet30</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>writeAttributeScriptEnabled</artifactId>
     <packaging>war</packaging>

--- a/test/servlet31/facelets/pom.xml
+++ b/test/servlet31/facelets/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet31</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>facelets</artifactId>
     <packaging>war</packaging>

--- a/test/servlet31/faceletsEmptyAsNull/pom.xml
+++ b/test/servlet31/faceletsEmptyAsNull/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet31</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>faceletsEmptyAsNull</artifactId>
     <packaging>war</packaging>

--- a/test/servlet31/faceletsID/pom.xml
+++ b/test/servlet31/faceletsID/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet31</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>faceletsID</artifactId>
     <packaging>war</packaging>

--- a/test/servlet31/pom.xml
+++ b/test/servlet31/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <groupId>com.sun.faces.test.servlet31</groupId>

--- a/test/servlet31/resourcehandler/pom.xml
+++ b/test/servlet31/resourcehandler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet31</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>resourcehandler</artifactId>
     <packaging>war</packaging>

--- a/test/servlet31/viewhandler/pom.xml
+++ b/test/servlet31/viewhandler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet31</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>viewhandler</artifactId>
     <packaging>war</packaging>

--- a/test/servlet40/el/pom.xml
+++ b/test/servlet40/el/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet40</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <groupId>com.sun.faces.test.servlet40</groupId>
     <artifactId>el</artifactId>

--- a/test/servlet40/exactMapping/pom.xml
+++ b/test/servlet40/exactMapping/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet40</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>exactMapping</artifactId>
     <packaging>war</packaging>	

--- a/test/servlet40/faceletCacheFactory/pom.xml
+++ b/test/servlet40/faceletCacheFactory/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet40</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>faceletCacheFactory</artifactId>
     <packaging>war</packaging>

--- a/test/servlet40/facelets/pom.xml
+++ b/test/servlet40/facelets/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet40</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>facelets</artifactId>
     <packaging>war</packaging>	

--- a/test/servlet40/getViews/pom.xml
+++ b/test/servlet40/getViews/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet40</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>getViews</artifactId>
     <packaging>war</packaging>	

--- a/test/servlet40/pom.xml
+++ b/test/servlet40/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <groupId>com.sun.faces.test.servlet40</groupId>

--- a/test/servlet40/refreshPeriodExplicit/pom.xml
+++ b/test/servlet40/refreshPeriodExplicit/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet40</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>refreshPeriodExplicit</artifactId>
     <packaging>war</packaging>

--- a/test/servlet40/refreshPeriodProduction/pom.xml
+++ b/test/servlet40/refreshPeriodProduction/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pom</artifactId>
         <groupId>com.sun.faces.test.servlet40</groupId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>refreshPeriodProduction</artifactId>
     <packaging>war</packaging>

--- a/test/servlet40/systemEvent/pom.xml
+++ b/test/servlet40/systemEvent/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test.servlet40</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>systemEvent</artifactId>
     <packaging>war</packaging>	

--- a/test/weblogic/elBackwardCompatible/pom.xml
+++ b/test/weblogic/elBackwardCompatible/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.weblogic</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>elBackwardCompatible</artifactId>
     <packaging>war</packaging>

--- a/test/weblogic/facelets/pom.xml
+++ b/test/weblogic/facelets/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.sun.faces.test.weblogic</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>facelets</artifactId>
     <packaging>war</packaging>

--- a/test/weblogic/pom.xml
+++ b/test/weblogic/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.sun.faces.test</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
  
     <groupId>com.sun.faces.test.weblogic</groupId>

--- a/test/weblogic/requestCharEncoding/pom.xml
+++ b/test/weblogic/requestCharEncoding/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.sun.faces.test.weblogic</groupId>
         <artifactId>pom</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     <artifactId>requestCharEncoding</artifactId>
     <packaging>war</packaging>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>2.3.18.payara-p1</version>
+        <version>2.3.18.payara-p2</version>
     </parent>
     
     <groupId>com.sun.faces</groupId>


### PR DESCRIPTION
Fix for https://github.com/payara/patched-src-mojarra/pull/17
The original change caused issue in Faces TCK:
```
TypeError: Cannot find function startsWith in object javax.faces.behavior.event.
```

I replaced the startsWith with a regex in jsf-uncompressed.js, which works more reliably. I tried the Faces TCK as well.
