### PR TITLE
FISH-9992 FISH-10056 FISH-10072 Mojarra 4.0.9

### DIFF
--- a/action/pom.xml
+++ b/action/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/action/pom.xml
+++ b/action/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -29,7 +29,7 @@
    <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
    <artifactId>jakarta.faces</artifactId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -29,7 +29,7 @@
    <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
    <artifactId>jakarta.faces</artifactId>

--- a/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
+++ b/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
@@ -458,6 +458,10 @@ public class MultiViewHandler extends ViewHandler {
      * @since 1.2
      */
     protected String normalizeRequestURI(String viewId, String mapping) {
+        if (mapping.isEmpty()) {
+            return viewId;
+        }
+        
         boolean logged = false;
 
         while (viewId.startsWith(mapping)) {

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
    <groupId>org.glassfish</groupId>
    <artifactId>mojarra-parent</artifactId>
-   <version>4.0.9.payara-p1</version>
+   <version>4.0.9.payara-p2-SNAPSHOT</version>
    <packaging>pom</packaging>
 
    <name>Mojarra ${project.version} - Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
    <groupId>org.glassfish</groupId>
    <artifactId>mojarra-parent</artifactId>
-   <version>4.0.9.payara-p1-SNAPSHOT</version>
+   <version>4.0.9.payara-p1</version>
    <packaging>pom</packaging>
 
    <name>Mojarra ${project.version} - Project</name>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>base</artifactId>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <artifactId>base</artifactId>

--- a/test/example_jar_with_metadata_complete_false/pom.xml
+++ b/test/example_jar_with_metadata_complete_false/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_false</artifactId>

--- a/test/example_jar_with_metadata_complete_false/pom.xml
+++ b/test/example_jar_with_metadata_complete_false/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_false</artifactId>

--- a/test/example_jar_with_metadata_complete_true/pom.xml
+++ b/test/example_jar_with_metadata_complete_true/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_true</artifactId>

--- a/test/example_jar_with_metadata_complete_true/pom.xml
+++ b/test/example_jar_with_metadata_complete_true/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_true</artifactId>

--- a/test/issue5460/pom.xml
+++ b/test/issue5460/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <artifactId>issue5460</artifactId>

--- a/test/issue5460/pom.xml
+++ b/test/issue5460/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5460</artifactId>

--- a/test/issue5464/pom.xml
+++ b/test/issue5464/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <artifactId>issue5464</artifactId>

--- a/test/issue5464/pom.xml
+++ b/test/issue5464/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5464</artifactId>

--- a/test/issue5488/pom.xml
+++ b/test/issue5488/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5488</artifactId>

--- a/test/issue5488/pom.xml
+++ b/test/issue5488/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <artifactId>issue5488</artifactId>

--- a/test/issue5503/pom.xml
+++ b/test/issue5503/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5503</artifactId>

--- a/test/issue5503/pom.xml
+++ b/test/issue5503/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <artifactId>issue5503</artifactId>

--- a/test/issue5507/pom.xml
+++ b/test/issue5507/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5507</artifactId>

--- a/test/issue5507/pom.xml
+++ b/test/issue5507/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <artifactId>issue5507</artifactId>

--- a/test/issue5511/pom.xml
+++ b/test/issue5511/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5511</artifactId>

--- a/test/issue5511/pom.xml
+++ b/test/issue5511/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <artifactId>issue5511</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.9.payara-p1</version>
+        <version>4.0.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra.test</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.9.payara-p1-SNAPSHOT</version>
+        <version>4.0.9.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra.test</groupId>


### PR DESCRIPTION
Reapplies our patches on top of Mojarra 4.0.9

Release tag provisionally pushed: https://github.com/payara/patched-src-mojarra/releases/tag/mojarra-4.0.9.payara-p1

Also includes https://github.com/eclipse-ee4j/mojarra/pull/5526