### PR TITLE
FISH-9896 Reapply Outstanding Patches to Mojarra 4.1.4

### DIFF
--- a/action/pom.xml
+++ b/action/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/action/pom.xml
+++ b/action/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -29,7 +29,7 @@
    <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
    <artifactId>jakarta.faces</artifactId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -29,7 +29,7 @@
    <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
    <artifactId>jakarta.faces</artifactId>

--- a/impl/src/main/java/com/sun/faces/cdi/ApplicationMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ApplicationMapProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.ApplicationMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -41,13 +40,10 @@ public class ApplicationMapProducer extends CdiProducer<Map<String, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ApplicationMapProducer(BeanManager beanManager) {
-        super.name("applicationScope")
-            .scope(ApplicationScoped.class)
-            .qualifiers(ApplicationMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getApplicationMap());
+    public ApplicationMapProducer() {
+        super.name("applicationScope").scope(ApplicationScoped.class).qualifiers(ApplicationMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getApplicationMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ApplicationProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ApplicationProducer.java
@@ -16,12 +16,7 @@
 
 package com.sun.faces.cdi;
 
-import static com.sun.faces.util.ReflectionUtils.findClass;
-
-import java.util.Optional;
-
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 
@@ -31,25 +26,17 @@ import jakarta.faces.context.FacesContext;
  * </p>
  *
  * @since 2.3
- * @see ExternalContext#getContext()
+ * @see ExternalContext
  */
 public class ApplicationProducer extends CdiProducer<Object> {
-
-    private static final Optional<Class<?>> SERVLET_CONTEXT_CLASS = findClass("jakarta.servlet.ServletContext");
 
     /**
      * Serialization version
      */
     private static final long serialVersionUID = 1L;
 
-    public ApplicationProducer(BeanManager beanManager) {
-        CdiProducer<Object> producer = super.name("application").scope(ApplicationScoped.class);
-
-        if (SERVLET_CONTEXT_CLASS.isPresent()) {
-            producer = producer.beanClass(beanManager, SERVLET_CONTEXT_CLASS.get()); // #5561
-        }
-
-        producer.create(e -> FacesContext.getCurrentInstance().getExternalContext().getContext());
+    public ApplicationProducer() {
+        super.name("application").scope(ApplicationScoped.class).create(e -> FacesContext.getCurrentInstance().getExternalContext().getContext());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/CdiExtension.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiExtension.java
@@ -180,27 +180,27 @@ public class CdiExtension implements Extension {
         // but this is not detectable as ServletContext is not necessarily available at this moment.
 
         afterBeanDiscovery.addBean(new ApplicationProducer());
-        afterBeanDiscovery.addBean(new ApplicationMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new ComponentProducer(beanManager));
-        afterBeanDiscovery.addBean(new FlashProducer(beanManager));
+        afterBeanDiscovery.addBean(new ApplicationMapProducer());
+        afterBeanDiscovery.addBean(new ComponentProducer());
+        afterBeanDiscovery.addBean(new FlashProducer());
         afterBeanDiscovery.addBean(new FlowProducer(beanManager));
-        afterBeanDiscovery.addBean(new FlowMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new HeaderMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new HeaderValuesMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new InitParameterMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new RequestParameterMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new RequestParameterValuesMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new FlowMapProducer());
+        afterBeanDiscovery.addBean(new HeaderMapProducer());
+        afterBeanDiscovery.addBean(new HeaderValuesMapProducer());
+        afterBeanDiscovery.addBean(new InitParameterMapProducer());
+        afterBeanDiscovery.addBean(new RequestParameterMapProducer());
+        afterBeanDiscovery.addBean(new RequestParameterValuesMapProducer());
         afterBeanDiscovery.addBean(new RequestProducer());
-        afterBeanDiscovery.addBean(new RequestMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new ResourceHandlerProducer(beanManager));
-        afterBeanDiscovery.addBean(new ExternalContextProducer(beanManager));
-        afterBeanDiscovery.addBean(new FacesContextProducer(beanManager));
-        afterBeanDiscovery.addBean(new RequestCookieMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new RequestMapProducer());
+        afterBeanDiscovery.addBean(new ResourceHandlerProducer());
+        afterBeanDiscovery.addBean(new ExternalContextProducer());
+        afterBeanDiscovery.addBean(new FacesContextProducer());
+        afterBeanDiscovery.addBean(new RequestCookieMapProducer());
         afterBeanDiscovery.addBean(new SessionProducer());
-        afterBeanDiscovery.addBean(new SessionMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new ViewMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new ViewProducer(beanManager));
-        afterBeanDiscovery.addBean(new DataModelClassesMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new SessionMapProducer());
+        afterBeanDiscovery.addBean(new ViewMapProducer());
+        afterBeanDiscovery.addBean(new ViewProducer());
+        afterBeanDiscovery.addBean(new DataModelClassesMapProducer());
 
         for (Type type : managedPropertyTargetTypes) {
             afterBeanDiscovery.addBean(new ManagedPropertyProducer(type, beanManager));

--- a/impl/src/main/java/com/sun/faces/cdi/CdiExtension.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiExtension.java
@@ -179,7 +179,7 @@ public class CdiExtension implements Extension {
         // Ideally below should only happen if Jakarta Faces is considered active,
         // but this is not detectable as ServletContext is not necessarily available at this moment.
 
-        afterBeanDiscovery.addBean(new ApplicationProducer(beanManager));
+        afterBeanDiscovery.addBean(new ApplicationProducer());
         afterBeanDiscovery.addBean(new ApplicationMapProducer(beanManager));
         afterBeanDiscovery.addBean(new ComponentProducer(beanManager));
         afterBeanDiscovery.addBean(new FlashProducer(beanManager));
@@ -190,13 +190,13 @@ public class CdiExtension implements Extension {
         afterBeanDiscovery.addBean(new InitParameterMapProducer(beanManager));
         afterBeanDiscovery.addBean(new RequestParameterMapProducer(beanManager));
         afterBeanDiscovery.addBean(new RequestParameterValuesMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new RequestProducer(beanManager));
+        afterBeanDiscovery.addBean(new RequestProducer());
         afterBeanDiscovery.addBean(new RequestMapProducer(beanManager));
         afterBeanDiscovery.addBean(new ResourceHandlerProducer(beanManager));
         afterBeanDiscovery.addBean(new ExternalContextProducer(beanManager));
         afterBeanDiscovery.addBean(new FacesContextProducer(beanManager));
         afterBeanDiscovery.addBean(new RequestCookieMapProducer(beanManager));
-        afterBeanDiscovery.addBean(new SessionProducer(beanManager));
+        afterBeanDiscovery.addBean(new SessionProducer());
         afterBeanDiscovery.addBean(new SessionMapProducer(beanManager));
         afterBeanDiscovery.addBean(new ViewMapProducer(beanManager));
         afterBeanDiscovery.addBean(new ViewProducer(beanManager));

--- a/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
@@ -31,7 +31,6 @@ import java.util.function.Function;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.PassivationCapable;
 import jakarta.faces.context.FacesContext;
@@ -50,7 +49,8 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
 
     private String id = this.getClass().getName();
     private String name;
-    private Class<?> beanClass = Object.class;
+    // for synthetic beans, the beanClass defaults to the extension that registers them
+    private Class<?> beanClass = CdiExtension.class;
     private Set<Type> types = singleton(Object.class);
     private Set<Annotation> qualifiers = unmodifiableSet(asSet(new DefaultAnnotationLiteral(), new AnyAnnotationLiteral()));
     private Class<? extends Annotation> scope = Dependent.class;
@@ -165,19 +165,8 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
         return this;
     }
 
-    protected CdiProducer<T> beanClass(BeanManager beanManager, Class<?> beanClass) {
-        if (CdiUtils.isWeld(beanManager)) {
-            this.beanClass = CdiExtension.class; // See #5457 and #5157
-        } else {
-            this.beanClass = beanClass;
-        }
-
-        return this;
-    }
-
     protected CdiProducer<T> types(Type... types) {
         this.types = asSet(types);
-        this.types.add(getClass()); // Add producer class as well so it can at least be filtered from BeanManager#getBeans().
         return this;
     }
 

--- a/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
@@ -418,11 +418,4 @@ public final class CdiUtils {
         }
     }
 
-    /**
-     * Returns true if Weld is used as CDI impl.
-     */
-    public static boolean isWeld(BeanManager beanManager) {
-        return beanManager.getClass().getPackageName().startsWith("org.jboss.weld.");
-    }
-
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ComponentProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ComponentProducer.java
@@ -18,7 +18,6 @@ package com.sun.faces.cdi;
 
 import static jakarta.faces.component.UIComponent.getCurrentComponent;
 
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
 
@@ -37,11 +36,8 @@ public class ComponentProducer extends CdiProducer<UIComponent> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ComponentProducer(BeanManager beanManager) {
-        super.name("component")
-            .beanClass(beanManager, UIComponent.class)
-            .types(UIComponent.class)
-            .create(e -> getCurrentComponent(FacesContext.getCurrentInstance()));
+    public ComponentProducer() {
+        super.name("component").types(UIComponent.class).create(e -> getCurrentComponent(FacesContext.getCurrentInstance()));
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/DataModelClassesMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/DataModelClassesMapProducer.java
@@ -19,7 +19,6 @@ package com.sun.faces.cdi;
 import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.faces.model.DataModel;
 
@@ -44,13 +43,9 @@ public class DataModelClassesMapProducer extends CdiProducer<Map<Class<?>, Class
      */
     private static final long serialVersionUID = 1L;
 
-    public DataModelClassesMapProducer(BeanManager beanManager) {
-        super.name("comSunFacesDataModelClassesMap")
-            .scope(ApplicationScoped.class)
-            .qualifiers(new DataModelClassesAnnotationLiteral())
-            .beanClass(beanManager, Map.class)
-            .types(Map.class, Object.class)
-            .create(e -> CDI.current().select(CdiExtension.class).get().getForClassToDataModelClass());
+    public DataModelClassesMapProducer() {
+        super.name("comSunFacesDataModelClassesMap").scope(ApplicationScoped.class).qualifiers(new DataModelClassesAnnotationLiteral())
+                .types(Map.class, Object.class).create(e -> CDI.current().select(CdiExtension.class).get().getForClassToDataModelClass());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ExternalContextProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ExternalContextProducer.java
@@ -17,7 +17,6 @@
 package com.sun.faces.cdi;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 
@@ -37,12 +36,9 @@ public class ExternalContextProducer extends CdiProducer<ExternalContext> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ExternalContextProducer(BeanManager beanManager) {
-        super.name("externalContext")
-            .scope(RequestScoped.class)
-            .beanClass(beanManager, ExternalContext.class)
-            .types(ExternalContext.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext());
+    public ExternalContextProducer() {
+        super.name("externalContext").scope(RequestScoped.class).types(ExternalContext.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/FacesContextProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/FacesContextProducer.java
@@ -17,7 +17,6 @@
 package com.sun.faces.cdi;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.context.FacesContext;
 
 /**
@@ -36,12 +35,9 @@ public class FacesContextProducer extends CdiProducer<FacesContext> {
      */
     private static final long serialVersionUID = 1L;
 
-    public FacesContextProducer(BeanManager beanManager) {
-        super.name("facesContext")
-            .scope(RequestScoped.class)
-            .beanClass(beanManager, FacesContext.class)
-            .types(FacesContext.class)
-            .create(e -> FacesContext.getCurrentInstance());
+    public FacesContextProducer() {
+        super.name("facesContext").scope(RequestScoped.class).types(FacesContext.class)
+                .create(e -> FacesContext.getCurrentInstance());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/FlashProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/FlashProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.Flash;
 
@@ -41,12 +40,10 @@ public class FlashProducer extends CdiProducer<Object> {
     private static class Dummy {
     }
 
-    public FlashProducer(BeanManager beanManager) {
+    public FlashProducer() {
         super.name("flash")
-            .beanClass(beanManager, Flash.class)
-            .types(Flash.class, new ParameterizedTypeImpl(Map.class, new Type[] { Dummy.class, Dummy.class }), Object.class)
-            .scope(RequestScoped.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getFlash());
+                .types(Flash.class, new ParameterizedTypeImpl(Map.class, new Type[] { Dummy.class, Dummy.class }), Object.class).scope(RequestScoped.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getFlash());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/FlowMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/FlowMapProducer.java
@@ -19,7 +19,6 @@ package com.sun.faces.cdi;
 import java.lang.reflect.Type;
 import java.util.Map;
 
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.FlowMap;
 import jakarta.faces.application.Application;
 import jakarta.faces.context.FacesContext;
@@ -42,13 +41,10 @@ public class FlowMapProducer extends CdiProducer<Map<Object, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public FlowMapProducer(BeanManager beanManager) {
-        super.name("flowScope")
-            .scope(FlowScoped.class)
-            .qualifiers(FlowMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { Object.class, Object.class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getApplication().getFlowHandler().getCurrentFlowScope());
+    public FlowMapProducer() {
+        super.name("flowScope").scope(FlowScoped.class).qualifiers(FlowMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { Object.class, Object.class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getApplication().getFlowHandler().getCurrentFlowScope());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/FlowProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/FlowProducer.java
@@ -35,7 +35,7 @@ public class FlowProducer extends CdiProducer<Flow> {
     private static final long serialVersionUID = 1L;
 
     public FlowProducer(BeanManager beanManager) {
-        super.name("flow").scope(RequestScoped.class).beanClass(beanManager, Flow.class).types(Flow.class)
+        super.name("flow").scope(RequestScoped.class).types(Flow.class)
             .create(e -> FacesContext.getCurrentInstance().getApplication().getFlowHandler().getCurrentFlow());
     }
 

--- a/impl/src/main/java/com/sun/faces/cdi/HeaderMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/HeaderMapProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.HeaderMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -40,13 +39,10 @@ public class HeaderMapProducer extends CdiProducer<Map<String, String>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public HeaderMapProducer(BeanManager beanManager) {
-        super.name("header")
-            .scope(RequestScoped.class)
-            .qualifiers(HeaderMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderMap());
+    public HeaderMapProducer() {
+        super.name("header").scope(RequestScoped.class).qualifiers(HeaderMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/HeaderValuesMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/HeaderValuesMapProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.HeaderValuesMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -40,13 +39,10 @@ public class HeaderValuesMapProducer extends CdiProducer<Map<String, String[]>> 
      */
     private static final long serialVersionUID = 1L;
 
-    public HeaderValuesMapProducer(BeanManager beanManager) {
-        super.name("headerValues")
-            .scope(RequestScoped.class)
-            .qualifiers(HeaderValuesMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderValuesMap());
+    public HeaderValuesMapProducer() {
+        super.name("headerValues").scope(RequestScoped.class).qualifiers(HeaderValuesMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderValuesMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/InitParameterMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/InitParameterMapProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.InitParameterMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -40,13 +39,10 @@ public class InitParameterMapProducer extends CdiProducer<Map<String, String>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public InitParameterMapProducer(BeanManager beanManager) {
-        super.name("initParam")
-            .scope(RequestScoped.class)
-            .qualifiers(InitParameterMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getInitParameterMap());
+    public InitParameterMapProducer() {
+        super.name("initParam").scope(RequestScoped.class).qualifiers(InitParameterMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getInitParameterMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ManagedPropertyProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ManagedPropertyProducer.java
@@ -44,11 +44,7 @@ public class ManagedPropertyProducer extends CdiProducer<Object> {
     private Class<?> expectedClass;
 
     public ManagedPropertyProducer(Type type, BeanManager beanManager) {
-        super.qualifiers(ManagedProperty.Literal.INSTANCE)
-            .beanClass(beanManager, ManagedPropertyProducer.class)
-            .types(type)
-            .addToId(type)
-            .create(creationalContext -> {
+        super.types(type).qualifiers(ManagedProperty.Literal.INSTANCE).addToId(type).create(creationalContext -> {
 
             // TODO: handle no InjectionPoint available
             String expression = getCurrentInjectionPoint(beanManager, creationalContext).getAnnotated().getAnnotation(ManagedProperty.class).value();

--- a/impl/src/main/java/com/sun/faces/cdi/RequestCookieMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestCookieMapProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.RequestCookieMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -41,13 +40,10 @@ public class RequestCookieMapProducer extends CdiProducer<Map<String, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public RequestCookieMapProducer(BeanManager beanManager) {
-        super.name("cookie")
-            .scope(RequestScoped.class)
-            .qualifiers(RequestCookieMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestCookieMap());
+    public RequestCookieMapProducer() {
+        super.name("cookie").scope(RequestScoped.class).qualifiers(RequestCookieMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestCookieMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/RequestMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestMapProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.RequestMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -40,13 +39,10 @@ public class RequestMapProducer extends CdiProducer<Map<String, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public RequestMapProducer(BeanManager beanManager) {
-        super.name("requestScope")
-            .scope(RequestScoped.class)
-            .qualifiers(RequestMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestMap());
+    public RequestMapProducer() {
+        super.name("requestScope").scope(RequestScoped.class).qualifiers(RequestMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/RequestParameterMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestParameterMapProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.RequestParameterMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -41,13 +40,10 @@ public class RequestParameterMapProducer extends CdiProducer<Map<String, String>
      */
     private static final long serialVersionUID = 1L;
 
-    public RequestParameterMapProducer(BeanManager beanManager) {
-        super.name("param")
-            .scope(RequestScoped.class)
-            .qualifiers(RequestParameterMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap());
+    public RequestParameterMapProducer() {
+        super.name("param").scope(RequestScoped.class).qualifiers(RequestParameterMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/RequestParameterValuesMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestParameterValuesMapProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.RequestParameterValuesMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -41,13 +40,10 @@ public class RequestParameterValuesMapProducer extends CdiProducer<Map<String, S
      */
     private static final long serialVersionUID = 1L;
 
-    public RequestParameterValuesMapProducer(BeanManager beanManager) {
-        super.name("paramValues")
-            .scope(RequestScoped.class)
-            .qualifiers(RequestParameterValuesMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestParameterValuesMap());
+    public RequestParameterValuesMapProducer() {
+        super.name("paramValues").scope(RequestScoped.class).qualifiers(RequestParameterValuesMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestParameterValuesMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/RequestProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestProducer.java
@@ -16,12 +16,7 @@
 
 package com.sun.faces.cdi;
 
-import static com.sun.faces.util.ReflectionUtils.findClass;
-
-import java.util.Optional;
-
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 
@@ -35,21 +30,13 @@ import jakarta.faces.context.FacesContext;
  */
 public class RequestProducer extends CdiProducer<Object> {
 
-    private static final Optional<Class<?>> HTTP_SERVLET_REQUEST_CLASS = findClass("jakarta.servlet.http.HttpServletRequest");
-
     /**
      * Serialization version
      */
     private static final long serialVersionUID = 1L;
 
-    public RequestProducer(BeanManager beanManager) {
-        CdiProducer<Object> producer = super.name("request").scope(RequestScoped.class);
-
-        if (HTTP_SERVLET_REQUEST_CLASS.isPresent()) {
-            producer = producer.beanClass(beanManager, HTTP_SERVLET_REQUEST_CLASS.get()); // #5561
-        }
-
-        producer.create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequest());
+    public RequestProducer() {
+        super.name("request").scope(RequestScoped.class).create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequest());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ResourceHandlerProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ResourceHandlerProducer.java
@@ -16,10 +16,7 @@
 
 package com.sun.faces.cdi;
 
-import java.util.Map;
-
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.application.Application;
 import jakarta.faces.application.ResourceHandler;
 import jakarta.faces.context.FacesContext;
@@ -41,12 +38,9 @@ public class ResourceHandlerProducer extends CdiProducer<ResourceHandler> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ResourceHandlerProducer(BeanManager beanManager) {
-        super.name("resource")
-            .scope(RequestScoped.class)
-            .beanClass(beanManager, ResourceHandler.class)
-            .types(ResourceHandler.class)
-            .create(e -> FacesContext.getCurrentInstance().getApplication().getResourceHandler());
+    public ResourceHandlerProducer() {
+        super.name("resource").scope(RequestScoped.class).types(ResourceHandler.class)
+                .create(e -> FacesContext.getCurrentInstance().getApplication().getResourceHandler());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/SessionMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/SessionMapProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.SessionMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -40,13 +39,10 @@ public class SessionMapProducer extends CdiProducer<Map<String, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public SessionMapProducer(BeanManager beanManager) {
-        super.name("sessionScope")
-            .scope(RequestScoped.class)
-            .qualifiers(SessionMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getSessionMap());
+    public SessionMapProducer() {
+        super.name("sessionScope").scope(RequestScoped.class).qualifiers(SessionMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getSessionMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/SessionProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/SessionProducer.java
@@ -16,12 +16,7 @@
 
 package com.sun.faces.cdi;
 
-import static com.sun.faces.util.ReflectionUtils.findClass;
-
-import java.util.Optional;
-
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 
@@ -35,21 +30,14 @@ import jakarta.faces.context.FacesContext;
  */
 public class SessionProducer extends CdiProducer<Object> {
 
-    private static final Optional<Class<?>> HTTP_SESSION_CLASS = findClass("jakarta.servlet.http.HttpSession");
-
     /**
      * Serialization version
      */
     private static final long serialVersionUID = 1L;
 
-    public SessionProducer(BeanManager beanManager) {
-        CdiProducer<Object> producer = super.name("session").scope(RequestScoped.class); // #5222
+    public SessionProducer() {
+        super.name("session").scope(RequestScoped.class).create(e -> FacesContext.getCurrentInstance().getExternalContext().getSession(false));
 
-        if (HTTP_SESSION_CLASS.isPresent()) {
-            producer = producer.beanClass(beanManager, HTTP_SESSION_CLASS.get()); // #5561
-        }
-
-        producer.create(e -> FacesContext.getCurrentInstance().getExternalContext().getSession(false));
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ViewMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ViewMapProducer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.ViewMap;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
@@ -41,13 +40,10 @@ public class ViewMapProducer extends CdiProducer<Map<String, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ViewMapProducer(BeanManager beanManager) {
-        super.name("viewScope")
-            .scope(RequestScoped.class)
-            .qualifiers(ViewMap.Literal.INSTANCE)
-            .beanClass(beanManager, Map.class)
-            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
-            .create(e -> FacesContext.getCurrentInstance().getViewRoot().getViewMap());
+    public ViewMapProducer() {
+        super.name("viewScope").scope(RequestScoped.class).qualifiers(ViewMap.Literal.INSTANCE)
+                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+                .create(e -> FacesContext.getCurrentInstance().getViewRoot().getViewMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ViewProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ViewProducer.java
@@ -17,7 +17,6 @@
 package com.sun.faces.cdi;
 
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
 
@@ -36,12 +35,9 @@ public class ViewProducer extends CdiProducer<UIViewRoot> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ViewProducer(BeanManager beanManager) {
-        super.name("view")
-            .scope(RequestScoped.class)
-            .beanClass(beanManager, UIViewRoot.class)
-            .types(UIViewRoot.class)
-            .create(e -> FacesContext.getCurrentInstance().getViewRoot());
+    public ViewProducer() {
+        super.name("view").scope(RequestScoped.class).types(UIViewRoot.class)
+                .create(e -> FacesContext.getCurrentInstance().getViewRoot());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
@@ -31,7 +31,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.sun.faces.cdi.CdiExtension;
-import com.sun.faces.cdi.FacesContextProducer;
 import com.sun.faces.el.ELContextImpl;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.FacesLogger;
@@ -553,7 +552,7 @@ public class FacesContextImpl extends FacesContext {
         DEFAULT_FACES_CONTEXT.remove();
 
         // Destroy our instance produced by FacesContextProducer.
-        Set<Bean<?>> beans = beanManager.getBeans(FacesContext.class).stream().filter(bean -> bean.getTypes().contains(FacesContextProducer.class)).collect(toSet());
+        Set<Bean<?>> beans = beanManager.getBeans(FacesContext.class).stream().filter(bean -> CdiExtension.class.isAssignableFrom(bean.getBeanClass())).collect(toSet());
         Bean<?> bean = beanManager.resolve(beans);
         ((AlterableContext) beanManager.getContext(bean.getScope())).destroy(bean);
     }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/TagAttributeImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/TagAttributeImpl.java
@@ -399,8 +399,12 @@ public class TagAttributeImpl extends TagAttribute {
                         "Successfully resolved expression '" + lookupExpression.getExpressionString() + "', but the value is not a MethodExpression");
             }
 
-            return ((MethodExpression) result).invoke(elContext, args);
-
+            try {
+                Object object = ((MethodExpression) result).invoke(elContext, args);
+                return object;
+            } catch(RuntimeException e) {
+                throw new IllegalArgumentException(e);
+            }
         }
 
         @Override

--- a/impl/src/main/java/com/sun/faces/util/ReflectionUtils.java
+++ b/impl/src/main/java/com/sun/faces/util/ReflectionUtils.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -223,17 +222,6 @@ public final class ReflectionUtils {
             }
 
             throw new IllegalStateException(e);
-        }
-    }
-
-    /**
-     * Returns the {@link Class} instance of {@link #toClass(String)}, or else an empty {@link Optional} when it throws an exception for whatever reason.
-     */
-    public static Optional<Class<?>> findClass(String className) {
-        try {
-            return Optional.of(toClass(className));
-        } catch (Exception e) {
-            return Optional.empty();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
    <groupId>org.glassfish</groupId>
    <artifactId>mojarra-parent</artifactId>
-   <version>4.1.4.payara-p1-SNAPSHOT</version>
+   <version>4.1.4.payara-p1</version>
    <packaging>pom</packaging>
 
    <name>Mojarra ${project.version} - Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
    <groupId>org.glassfish</groupId>
    <artifactId>mojarra-parent</artifactId>
-   <version>4.1.4.payara-p1</version>
+   <version>4.1.4.payara-p2-SNAPSHOT</version>
    <packaging>pom</packaging>
 
    <name>Mojarra ${project.version} - Project</name>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>base</artifactId>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>base</artifactId>

--- a/test/example_jar_with_metadata_complete_false/pom.xml
+++ b/test/example_jar_with_metadata_complete_false/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_false</artifactId>

--- a/test/example_jar_with_metadata_complete_false/pom.xml
+++ b/test/example_jar_with_metadata_complete_false/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_false</artifactId>

--- a/test/example_jar_with_metadata_complete_true/pom.xml
+++ b/test/example_jar_with_metadata_complete_true/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_true</artifactId>

--- a/test/example_jar_with_metadata_complete_true/pom.xml
+++ b/test/example_jar_with_metadata_complete_true/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_true</artifactId>

--- a/test/issue5460/pom.xml
+++ b/test/issue5460/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5460</artifactId>

--- a/test/issue5460/pom.xml
+++ b/test/issue5460/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5460</artifactId>

--- a/test/issue5464/pom.xml
+++ b/test/issue5464/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5464</artifactId>

--- a/test/issue5464/pom.xml
+++ b/test/issue5464/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5464</artifactId>

--- a/test/issue5488/pom.xml
+++ b/test/issue5488/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5488</artifactId>

--- a/test/issue5488/pom.xml
+++ b/test/issue5488/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5488</artifactId>

--- a/test/issue5503/pom.xml
+++ b/test/issue5503/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5503</artifactId>

--- a/test/issue5503/pom.xml
+++ b/test/issue5503/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5503</artifactId>

--- a/test/issue5507/pom.xml
+++ b/test/issue5507/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5507</artifactId>

--- a/test/issue5507/pom.xml
+++ b/test/issue5507/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5507</artifactId>

--- a/test/issue5511/pom.xml
+++ b/test/issue5511/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5511</artifactId>

--- a/test/issue5511/pom.xml
+++ b/test/issue5511/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5511</artifactId>

--- a/test/issue5515/pom.xml
+++ b/test/issue5515/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5515</artifactId>

--- a/test/issue5515/pom.xml
+++ b/test/issue5515/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5515</artifactId>

--- a/test/issue5541/pom.xml
+++ b/test/issue5541/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5541</artifactId>

--- a/test/issue5541/pom.xml
+++ b/test/issue5541/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5541</artifactId>

--- a/test/issue5543/pom.xml
+++ b/test/issue5543/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5543</artifactId>

--- a/test/issue5543/pom.xml
+++ b/test/issue5543/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5543</artifactId>

--- a/test/issue5576/pom.xml
+++ b/test/issue5576/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5576</artifactId>

--- a/test/issue5576/pom.xml
+++ b/test/issue5576/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5576</artifactId>

--- a/test/issue5584/pom.xml
+++ b/test/issue5584/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5584</artifactId>

--- a/test/issue5584/pom.xml
+++ b/test/issue5584/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5584</artifactId>

--- a/test/issue5594/pom.xml
+++ b/test/issue5594/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5594</artifactId>

--- a/test/issue5594/pom.xml
+++ b/test/issue5594/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5594</artifactId>

--- a/test/issue5596/pom.xml
+++ b/test/issue5596/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <artifactId>issue5596</artifactId>

--- a/test/issue5596/pom.xml
+++ b/test/issue5596/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5596</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.4.payara-p1-SNAPSHOT</version>
+        <version>4.1.4.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.mojarra.test</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.4.payara-p1</version>
+        <version>4.1.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra.test</groupId>


### PR DESCRIPTION
Skips a61858915dbdc7be1d790eed4d8c71990b6d096a and 6e99d5476905aab9f0f63385a83ed8db31cf917d due to no longer being relevant.
Applies an extra fix on top of FISH-11055 due to their being a new class introduced which also needs the reversions applied to it.

Both reproducers have been tested (after updating to EE11) as still being applicable without these changes, and fixed after these changes are applied.